### PR TITLE
Limit image width to 450px

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,10 @@
+---
+---
+
+@import "{{ site.theme }}";
+
+img {
+  max-width: 450px;
+  height: auto;
+}
+


### PR DESCRIPTION
## Summary
- Add a global CSS override so all images have a maximum width of 450px

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_b_689e33536c2883289ecb98df5126c00d